### PR TITLE
Read correct number of extended glyph names in post table

### DIFF
--- a/font-loader.lisp
+++ b/font-loader.lisp
@@ -122,4 +122,11 @@ named by TAG."
 
 (defmethod seek-to-table ((tag string) (font-loader font-loader))
   "Move FONT-LOADER's input stream to the start of the table named by TAG."
-  (file-position (input-stream font-loader) (table-position tag font-loader)))
+  (let ((table-info (table-info tag font-loader)))
+    (if table-info
+        (seek-to-table table-info font-loader)
+        (error "No such table -- ~A" tag))))
+
+(defmethod seek-to-table ((table table-info) (font-loader font-loader))
+  "Move FONT-LOADER's input stream to the start of TABLE."
+  (file-position (input-stream font-loader) (offset table)))


### PR DESCRIPTION
The specification describes the array of extended glyph names like this[1]:

```
int8 names[numberNewGlyphs] Glyph names with length bytes [variable] (a Pascal string).
```

but `numberNewGlyphs` is not defined in the surrounding text.

Before this change, zpb-ttf computed `numberNewGlyphs` based on the number of extended glyph names referenced in the glyph name index array preceding the above array. This seems to be incorrect since some fonts do not reference all extended glyph names in the glyph name index array. To see why this is a problem, consider the follow post table

```
  name indices 0 1 2 360
  names        "a" "b" "c" "d"
```


The "name indices" array references one extended glyph name, 360, which corresponds to index 2 and thus the name "c" in the "names" array. Going by the number of referenced extended glyph names, which is 1, would result in only reading the name "a" and being unable to access the array of read names at index 2.

This change makes `load-post-format-2` read extended glyph names until the end of the post table. With this approach, the array of read names would always be `#("a" "b" "c" "d")` in the above example, independent of how many of those are actually referenced.

[1] https://docs.microsoft.com/en-us/typography/opentype/spec/post#version-20