### PR TITLE
Fix reading of post table again

### DIFF
--- a/cmap.lisp
+++ b/cmap.lisp
@@ -26,7 +26,7 @@
 ;;;
 ;;; Loading data from the "cmap" table.
 ;;;
-;;;  http://www.microsoft.com/OpenType/OTSpec/cmap.htm
+;;;  https://docs.microsoft.com/en-us/typography/opentype/spec/cmap
 ;;;  http://developer.apple.com/fonts/TTRefMan/RM06/Chap6cmap.html
 ;;;
 ;;; $Id: cmap.lisp,v 1.15 2006/03/23 22:23:32 xach Exp $

--- a/doc/index.html
+++ b/doc/index.html
@@ -137,7 +137,7 @@ file format documentation. For file format details, see the
 specifications from either <a
 href="http://developer.apple.com/fonts/TTRefMan/RM06/Chap6.html">Apple</a>
 or <a
-href="http://www.microsoft.com/OpenType/OTSpec/otff.htm">Microsoft</a>.
+href="https://docs.microsoft.com/en-us/typography/opentype/spec/">Microsoft</a>.
 
 
 <a name='sect-glyph-example'><h3>Glyph Example</h3></a>

--- a/head.lisp
+++ b/head.lisp
@@ -26,7 +26,7 @@
 ;;;
 ;;; Loading data from the "head" table.
 ;;;
-;;;  http://www.microsoft.com/OpenType/OTSpec/head.htm
+;;;  https://docs.microsoft.com/en-us/typography/opentype/spec/head
 ;;;  http://developer.apple.com/fonts/TTRefMan/RM06/Chap6head.html
 ;;;
 ;;; $Id: head.lisp,v 1.5 2006/02/18 23:13:43 xach Exp $

--- a/hhea.lisp
+++ b/hhea.lisp
@@ -26,7 +26,7 @@
 ;;;
 ;;; Loading data from the "hhea" table.
 ;;;
-;;;  http://www.microsoft.com/OpenType/OTSpec/hhea.htm
+;;;  https://docs.microsoft.com/en-us/typography/opentype/spec/hhea
 ;;;  http://developer.apple.com/fonts/TTRefMan/RM06/Chap6hhea.html
 ;;;
 ;;; $Id: hhea.lisp,v 1.4 2006/02/18 23:13:43 xach Exp $

--- a/hmtx.lisp
+++ b/hmtx.lisp
@@ -26,7 +26,7 @@
 ;;;
 ;;; Loading data from the "hmtx" table.
 ;;;
-;;;  http://www.microsoft.com/OpenType/OTSpec/hmtx.htm
+;;;  https://docs.microsoft.com/en-us/typography/opentype/spec/hmtx
 ;;;  http://developer.apple.com/fonts/TTRefMan/RM06/Chap6hmtx.html
 ;;;
 ;;; $Id: hmtx.lisp,v 1.3 2006/02/18 23:13:43 xach Exp $

--- a/kern.lisp
+++ b/kern.lisp
@@ -26,7 +26,7 @@
 ;;;
 ;;; "kern" table functions
 ;;;
-;;;   http://www.microsoft.com/OpenType/OTSpec/kern.htm
+;;;   https://docs.microsoft.com/en-us/typography/opentype/spec/kern
 ;;;   http://developer.apple.com/fonts/TTRefMan/RM06/Chap6kern.html
 ;;;
 ;;; $Id: kern.lisp,v 1.8 2006/03/28 14:38:37 xach Exp $
@@ -69,7 +69,7 @@ distance between the pair."
       ;; implements Microsoft's version.
       ;; See:
       ;;  http://developer.apple.com/fonts/TTRefMan/RM06/Chap6kern.html
-      ;;  http://www.microsoft.com/OpenType/OTSpec/kern.htm
+      ;;  https://docs.microsoft.com/en-us/typography/opentype/spec/kern
       (if (zerop version)
           (setf version maybe-version
                 table-count maybe-table-count)

--- a/loca.lisp
+++ b/loca.lisp
@@ -26,7 +26,7 @@
 ;;;
 ;;; Loading data from the "loca" table.
 ;;;
-;;;  http://www.microsoft.com/OpenType/OTSpec/loca.htm
+;;;  https://docs.microsoft.com/en-us/typography/opentype/spec/loca
 ;;;  http://developer.apple.com/fonts/TTRefMan/RM06/Chap6loca.html
 ;;;
 ;;; $Id: loca.lisp,v 1.3 2006/02/18 23:13:43 xach Exp $

--- a/maxp.lisp
+++ b/maxp.lisp
@@ -26,7 +26,7 @@
 ;;;
 ;;; Loading data from the "maxp" table.
 ;;;
-;;;  http://www.microsoft.com/OpenType/OTSpec/maxp.htm
+;;;  https://docs.microsoft.com/en-us/typography/opentype/spec/maxp
 ;;;  http://developer.apple.com/fonts/TTRefMan/RM06/Chap6maxp.html
 ;;;
 ;;; $Id: maxp.lisp,v 1.3 2006/02/18 23:13:43 xach Exp $

--- a/name.lisp
+++ b/name.lisp
@@ -26,7 +26,7 @@
 ;;;
 ;;; Loading data from the TrueType "name" table.
 ;;;
-;;;   http://www.microsoft.com/OpenType/OTSpec/name.htm
+;;;   https://docs.microsoft.com/en-us/typography/opentype/spec/name
 ;;;   http://developer.apple.com/fonts/TTRefMan/RM06/Chap6name.html
 ;;;
 ;;; $Id: name.lisp,v 1.8 2006/02/18 23:13:43 xach Exp $

--- a/post.lisp
+++ b/post.lisp
@@ -259,7 +259,6 @@
     ;; preceding the indices might not reference all names.
     (let ((pstrings (make-array glyph-count :adjustable t :fill-pointer 0)))
       (loop with position = (+ 2 (* 2 glyph-count))
-            for i from 0
             while (< position size-without-header)
             do (let ((string (read-pstring stream)))
                  (vector-push-extend string pstrings)
@@ -283,7 +282,7 @@
          (table-info (table-info "post" font-loader)))
     (seek-to-table table-info font-loader)
     (let ((format (read-uint32 stream))
-          (header-size 16))
+          (header-size 32))
       (when (/= format #x00020000 #x00030000)
         (error 'unsupported-format
                :location "\"post\" table"
@@ -295,7 +294,7 @@
             (fixed-pitch-p font-loader) (plusp (read-uint32 stream))
             (postscript-glyph-names font-loader) names)
       ;; skip minMemType* fields
-      (advance-file-position stream header-size)
+      (advance-file-position stream (- header-size 16))
       (case format
         (#x00020000 (load-post-format-2
                      names stream (- (size table-info) header-size)))

--- a/post.lisp
+++ b/post.lisp
@@ -26,7 +26,7 @@
 ;;;
 ;;; "post" table functions
 ;;;
-;;;   http://www.microsoft.com/OpenType/OTSpec/post.htm
+;;;   https://docs.microsoft.com/en-us/typography/opentype/spec/post
 ;;;   http://developer.apple.com/fonts/TTRefMan/RM06/Chap6post.html
 ;;;
 ;;; $Id: post.lisp,v 1.7 2006/11/09 15:06:16 xach Exp $


### PR DESCRIPTION
The previous change (9aaa69ba) added a parameter for the data size to `load-post-format-2` to replace an incorrect computation based on the glyph count. However, the computed data size was also wrong because the size of the header of the post table is 32 bytes, not 16.