### PR TITLE
open-font-loader-from-file: open: add :sharing :external for CCL.

### DIFF
--- a/font-loader-interface.lisp
+++ b/font-loader-interface.lisp
@@ -125,7 +125,8 @@
 (defun open-font-loader-from-file (thing &key (collection-index 0))
   (let ((stream (open thing
                       :direction :input
-                      :element-type '(unsigned-byte 8))))
+                      :element-type '(unsigned-byte 8)
+                      #+ccl :sharing #+ccl :external)))
     (let ((font-loader (open-font-loader-from-stream
                         stream :collection-index collection-index)))
       (arrange-finalization font-loader stream)


### PR DESCRIPTION
Clozure Common Lisp by default restricts a stream usage to a single
thread. Other implementations allow asynchronous access - be explicit to allow
it on CCL too.