### PR TITLE
Bug fixes related to different curve types

### DIFF
--- a/cmap.lisp
+++ b/cmap.lisp
@@ -230,8 +230,9 @@ FONT-LOADER, if present, otherwise NIL.")
 
 (defmethod load-cmap-info ((font-loader font-loader))
   (or (%load-cmap-info font-loader +unicode-platform-id+
-                       +unicode-2.0-encoding-id+) ;; full unicode
-      (%load-cmap-info font-loader +microsoft-platform-id+ 10) ;; full unicode
+                       +unicode-2.0-full-encoding-id+) ;; full unicode
+      (%load-cmap-info font-loader +microsoft-platform-id+
+                       +microsoft-unicode-ucs4-encoding-id+) ;; full unicode
       (%load-cmap-info font-loader +microsoft-platform-id+
                        +microsoft-unicode-bmp-encoding-id+) ;; bmp
       (%load-cmap-info font-loader +unicode-platform-id+

--- a/name.lisp
+++ b/name.lisp
@@ -395,7 +395,9 @@
 (defconstant +custom-platform-id+    4)
 
 (defconstant +unicode-2.0-encoding-id+           3)
+(defconstant +unicode-2.0-full-encoding-id+      4)
 (defconstant +microsoft-unicode-bmp-encoding-id+ 1)
+(defconstant +microsoft-unicode-ucs4-encoding-id+ 10)
 (defconstant +microsoft-symbol-encoding-id+      0)
 (defconstant +macintosh-roman-encoding-id+       1)
 

--- a/test.lisp
+++ b/test.lisp
@@ -1,0 +1,121 @@
+(defpackage #:zpb-ttf-test
+  (:use :cl)
+  (:import-from :zpb-ttf
+                #:on-curve-p
+                #:x #:y
+                #:do-contour-segments*
+                #:do-contour-segments
+                #:explicit-contour-points)
+  (:local-nicknames (:z :zpb-ttf)))
+(in-package #:zpb-ttf-test)
+
+(defmacro contour (&rest points)
+  `(make-array ,(length points)
+               :initial-contents
+               (list ,@ (loop for (x y c) in points
+                              collect `(z::make-control-point ,x ,y ,c)))))
+(defun point= (a b)
+  (or (and (not a) (not b))
+      (and (typep a 'z::control-point)
+           (typep b 'z::control-point)
+           (eql (on-curve-p a) (on-curve-p b))
+           (eql (x a) (x b))
+           (eql (y a) (y b)))))
+
+(defun contour= (a b)
+  (and (= (length a) (length b))
+       (loop for a across a
+             for b across b
+             always (point= a b))))
+
+(defmacro check-dcs* (contour &body points)
+  `(let ((contour ,contour)
+         (points ',points))
+     (flet ((next-point ()
+              (let ((x (pop points)))
+                (when x
+                  (destructuring-bind (x y &optional c) x
+                    (z::make-control-point x y c ))))))
+       (do-contour-segments* (b c) contour
+         (assert (point= b (next-point)))
+         (assert (point= c (next-point))))
+       (assert (null points)))
+     t))
+
+(check-dcs* #())
+;; normal contour
+(check-dcs* (contour (0 0 t) (1 2) (3 4 t) (5 6))
+  (1 2) (3 4 t)
+  (5 6) (0 0 t))
+
+;; starts on control point
+(check-dcs* (contour (1 2) (3 4 t) (5 6) (0 0 t))
+  (1 2) (3 4 t)
+  (5 6) (0 0 t))
+
+;; only control points
+(check-dcs* (contour (0 0) (2 2) (4 0) (2 -2))
+  (0 0) (1 1 t)
+  (2 2) (3 1 t)
+  (4 0) (3 -1 t)
+  (2 -2) (1 -1 t))
+
+(defmacro check-dcs (contour &body points)
+  `(let ((contour ,contour)
+         (points ',points))
+     (flet ((next-point ()
+              (let ((x (pop points)))
+                (when x
+                  (destructuring-bind (x y &optional c) x
+                    (z::make-control-point x y c ))))))
+       (do-contour-segments (a b c) contour
+         (assert (point= a (next-point)))
+         (assert (point= b (next-point)))
+         (assert (point= c (next-point))))
+       (assert (null points)))
+     t))
+
+(check-dcs #())
+
+;; normal contour
+(check-dcs (contour (0 0 t) (1 2) (3 4 t) (5 6))
+  (0 0 t) (1 2) (3 4 t)
+  (3 4 t) (5 6) (0 0 t))
+
+;; starts on control point
+(check-dcs (contour (1 2) (3 4 t) (5 6) (0 0 t))
+  (0 0 t) (1 2) (3 4 t)
+  (3 4 t) (5 6) (0 0 t))
+
+;; only control points
+(check-dcs (contour (0 0) (2 2) (4 0) (2 -2))
+  (1 -1 t) (0 0) (1 1 t)
+  (1 1 t) (2 2) (3 1 t)
+  (3 1 t) (4 0) (3 -1 t)
+  (3 -1 t) (2 -2) (1 -1 t))
+
+(assert (contour= (contour (0 1) (2 3 t))
+                  (contour (0 1) (2 3 t))))
+
+(assert (not (contour= (contour (0 1 t) (2 3 t))
+                       (contour (0 1) (2 3 t)))))
+(assert (not (contour= (contour (0 1))
+                       (contour (0 1) (2 3 t)))))
+
+(assert (equalp (explicit-contour-points #()) #()))
+
+(assert
+ (contour= (explicit-contour-points (contour (0 0 t) (1 2) (3 4 t) (5 6)))
+           (contour (0 0 t) (1 2) (3 4 t) (5 6))))
+
+(assert
+ (contour= (explicit-contour-points (contour (1 2) (3 4 t) (5 6) (0 0 t)))
+           (contour (1 2) (3 4 t) (5 6) (0 0 t))))
+
+(assert
+ (contour= (explicit-contour-points (contour (0 0) (2 2) (4 0) (2 -2)))
+           (contour (0 0) (1 1 t)
+                    (2 2) (3 1 t)
+                    (4 0) (3 -1 t)
+                    (2 -2) (1 -1 t))))
+

--- a/util.lisp
+++ b/util.lisp
@@ -73,7 +73,7 @@
           (fraction (logand #x3FFF value)))
       (when (logbitp 1 integer)
         (setf integer (1- (- (logandc2 #b11 integer)))))
-      (+ integer (float (/ fraction #x3FFF))))))
+      (+ integer (float (/ fraction #x4000))))))
 
 (defun read-pstring (stream)
   "Read a Pascal-style length-prefixed string."


### PR DESCRIPTION
Hi, these are a few fixes for bugs that we require to properly handle contours of some of the more extravagant fonts out there. We already rely on these fixes in a SDF font atlas generation library, so it would be great to get them upstreamed and rolled out.