### PR TITLE
try to handle a wider variety of fonts, and optimize opening large files

### DIFF
--- a/cmap.lisp
+++ b/cmap.lisp
@@ -152,7 +152,7 @@ CMAP arrays (END-CODES etc) corresponding to code-point."
         ((< code-point start-code)
          0)
         ((and (= 65535 start-code (aref end-codes index))
-              (= 0 id-range-offsets id-delta))
+              (= 0 id-range-offset id-delta))
          0)
         ((zerop id-range-offset)
          (logand #xFFFF (+ code-point id-delta)))

--- a/cmap.lisp
+++ b/cmap.lisp
@@ -146,13 +146,14 @@ CMAP arrays (END-CODES etc) corresponding to code-point."
                    id-range-offsets
                    glyph-indexes))
     (let ((start-code (aref start-codes index))
+          (end-code (aref end-codes index))
           (id-range-offset (aref id-range-offsets index))
           (id-delta (aref id-deltas index)))
       (cond
         ((< code-point start-code)
          0)
-        ((and (= 65535 start-code (aref end-codes index))
-              (= 0 id-range-offset id-delta))
+        ;; ignore empty final segment
+        ((and (= 65535 start-code end-code))
          0)
         ((zerop id-range-offset)
          (logand #xFFFF (+ code-point id-delta)))

--- a/font-loader-interface.lisp
+++ b/font-loader-interface.lisp
@@ -45,6 +45,27 @@
     (excl:schedule-finalization object #'quietly-close)))
     
 
+(defun check-magic (magic &rest ok)
+  (cond
+    ((member magic ok)
+     t)
+    ((= magic (tag->number "typ1"))
+     (error 'unsupported-format
+            :location "font header"
+            :description "Old style of PostScript font housed in a sfnt wrapper not supported."
+            :actual-value magic
+            :expected-values ok))
+    ((= magic (tag->number "OTTO"))
+     (error 'unsupported-format
+            :location "font header"
+            :description "OpenType font with PostScript outlines not supported."
+            :actual-value magic
+            :expected-values ok))
+    (t
+     (error 'bad-magic
+            :location "font header"
+            :expected-values ok
+            :actual-value magic))))
 ;;;
 ;;; FIXME: move most/all of this stuff into initialize-instance
 ;;;
@@ -52,12 +73,10 @@
 (defun open-font-loader-from-stream (input-stream &key (collection-index 0))
   (let ((magic (read-uint32 input-stream))
         (font-count))
-    (when (/= magic #x00010000 #x74727565 #x74746366)
-      (error 'bad-magic
-             :location "font header"
-             :expected-values (list #x00010000 #x74727565 #x74746366)
-             :actual-value magic))
-    (when (= magic #x74746366)
+    (check-magic magic #x00010000
+                 (tag->number "true")
+                 (tag->number "ttcf"))
+    (when (= magic (tag->number "ttcf"))
       (let ((version (read-uint32 input-stream)))
         (check-version "ttc header" version #x00010000 #x00020000)
         (setf font-count (read-uint32 input-stream))
@@ -80,11 +99,7 @@
           ;; seek to font offset table
           (file-position input-stream (aref offset-table collection-index))
           (let ((magic2 (read-uint32 input-stream)))
-            (when (/= magic2 #x00010000 #x74727565)
-              (error 'bad-magic
-                     :location "font header"
-                     :expected-values (list #x00010000 #x74727565)
-                     :actual-value magic2))))))
+            (check-magic magic2 #x00010000 (tag->number "true"))))))
 
     (let* ((table-count (read-uint16 input-stream))
            (font-loader (make-instance 'font-loader

--- a/font-loader-interface.lisp
+++ b/font-loader-interface.lisp
@@ -136,7 +136,10 @@
   (typecase thing
     (font-loader
      (cond
-       ((= collection-index (collection-font-index thing))
+       ;; We either don't have a collection, or want same font from
+       ;; collection.
+       ((or (not (collection-font-index thing))
+            (= collection-index (collection-font-index thing)))
         (unless (open-stream-p (input-stream thing))
           (setf (input-stream thing) (open (input-stream thing))))
         thing)

--- a/glyph.lisp
+++ b/glyph.lisp
@@ -159,7 +159,7 @@ to look up information in various structures in the truetype file.")
                       (read-fword stream)
                       (read-fword stream)
                       (read-fword stream))))))
-  
+
 (defmethod initialize-contours ((glyph glyph))
   (if (zerop (data-size glyph))
       (setf (contours glyph) (empty-contours))
@@ -170,7 +170,8 @@ to look up information in various structures in the truetype file.")
           (advance-file-position stream 8)
           (if (= contour-count -1)
               (setf (contours glyph)
-                    (read-compound-contours (font-loader glyph)))
+                    (with-compound-contour-loop ()
+                      (read-compound-contours (font-loader glyph))))
               (setf (contours glyph)
                     (read-simple-contours contour-count stream)))))))
 

--- a/kern.lisp
+++ b/kern.lisp
@@ -33,28 +33,83 @@
 
 (in-package #:zpb-ttf)
 
-(defun load-kerning-format-1 (table stream)
+(defun load-kerning-format-0 (table stream)
   "Return a hash table keyed on a UINT32 key that represents the glyph
 index in the left and right halves with a value of the kerning
 distance between the pair."
   (let ((pair-count (read-uint16 stream))
         (search-range (read-uint16 stream))
         (entry-selector (read-uint16 stream))
-        (range-shift (read-uint16 stream)))
+        (range-shift (read-uint16 stream))
+        (bytes-read 8))
     (declare (ignore search-range entry-selector range-shift))
     (dotimes (i pair-count)
-      (setf (gethash (read-uint32 stream) table)
-            (read-int16 stream)))))
+      (let ((key (read-uint32 stream))
+            (value (read-int16 stream)))
+        ;; apple specifies a terminating entry, ignore it
+        (unless (and (= key #xffffffff) (= value 0))
+          (setf (gethash key table) value))
+        (incf bytes-read 6)))
+    bytes-read))
 
-(defmethod load-kerning-subtable ((font-loader font-loader) format)
-  (when (/= 1 format)
+(defun parse-offset-table (buffer start)
+  (let ((first-glyph (aref buffer start))
+        (glyph-count (aref buffer (1+ start)))
+        (offsets (make-hash-table)))
+    (loop for i from (+ start 2)
+          for g from first-glyph
+          repeat glyph-count
+          collect (setf (gethash g offsets) (aref buffer i)))
+    offsets))
+
+(defun load-kerning-format-2 (table stream size)
+  "Return a hash table keyed on a UINT32 key that represents the glyph
+index in the left and right halves with a value of the kerning
+distance between the pair."
+  (let* ((buffer (coerce (loop repeat (/ size 2)
+                               collect (read-uint16 stream))
+                         '(simple-array (unsigned-byte) 1)))
+         (row-width (aref buffer 0))
+         (left-offset-table (aref buffer 1))
+         (right-offset-table (aref buffer 2))
+         (array-offset (aref buffer 3))
+         (left (parse-offset-table buffer (- (/ left-offset-table 2) 4)))
+         (right (parse-offset-table buffer (- (/ right-offset-table 2) 4))))
+    (declare (ignorable row-width array-offset))
+    (flet ((s16 (x)
+             (if (logbitp 15 x)
+                 (1- (- (logandc2 #xFFFF x)))
+                 x)))
+      (maphash (lambda (lk lv)
+                 (maphash (lambda (rk rv)
+                            (let ((key (logior (ash lk 16) rk))
+                                  (value (s16 (aref buffer
+                                                    (- (/ (+ lv rv) 2) 4)))))
+                              (unless (zerop value)
+                                (setf (gethash key table) value))))
+                          right))
+               left))
+    size))
+
+(defmethod load-kerning-subtable ((font-loader font-loader) format size)
+  (when (/= format 0 1 2)
     (error 'unsupported-format
            :description "kerning subtable"
            :size 1
-           :expected-values (list 1)
+           :expected-values (list 0 1 2)
            :actual-value format))
-  (load-kerning-format-1 (kerning-table font-loader)
-                         (input-stream font-loader)))
+  (case format
+    (0
+     (load-kerning-format-0 (kerning-table font-loader)
+                            (input-stream font-loader)))
+    (1
+     ;; state table for contextual kerning, ignored for now
+     (advance-file-position (input-stream font-loader) (- size 8))
+     (- size 8))
+    (2
+     (load-kerning-format-2 (kerning-table font-loader)
+                            (input-stream font-loader)
+                            size))))
 
 (defmethod load-kern-info ((font-loader font-loader))
   (when (table-exists-p "kern" font-loader)
@@ -63,26 +118,52 @@ distance between the pair."
            (maybe-version (read-uint16 stream))
            (maybe-table-count (read-uint16 stream))
            (version 0)
-           (table-count 0))
+           (table-count 0)
+           (apple-p nil))
+
       ;; These shenanegins are because Apple documents one style of
       ;; kern table and Microsoft documents another. This code
-      ;; implements Microsoft's version.
+      ;; tries to support both.
       ;; See:
-      ;;  http://developer.apple.com/fonts/TTRefMan/RM06/Chap6kern.html
-      ;;  https://docs.microsoft.com/en-us/typography/opentype/spec/kern
-      (if (zerop version)
+      ;;  https://developer.apple.com/fonts/TrueType-Reference-Manual/RM06/Chap6kern.html
+      ;;  https://learn.microsoft.com/en-us/typography/opentype/spec/kern
+      (if (zerop maybe-version)
           (setf version maybe-version
                 table-count maybe-table-count)
           (setf version (logand (ash maybe-version 16) maybe-table-count)
-                table-count (read-uint32 stream)))
+                table-count (read-uint32 stream)
+                apple-p t))
       (check-version "\"kern\" table" version 0)
       (dotimes (i table-count)
         (let ((version (read-uint16 stream))
               (length (read-uint16 stream))
               (coverage-flags (read-uint8 stream))
               (format (read-uint8 stream)))
-          (declare (ignore version length coverage-flags))
-          (load-kerning-subtable font-loader format))))))
+          (declare (ignorable version))
+          (case coverage-flags
+            ;; only read horizontal kerning, since storing others in
+            ;; same array would be confusing and vertical layouts
+            ;; don't seem to be supported currently
+            (0
+             (when apple-p
+               (read-uint16 stream))    ; read and discard tuple-index
+
+             (let ((bytes-read (+ (load-kerning-subtable font-loader format
+                                                         length)
+                                  (if apple-p 8 6))))
+               (advance-file-position stream (- length bytes-read))))
+            ;; ignore other known types of kerning
+            ((#x8000  ;; vertical
+              #x4000  ;; cross stream
+              #x2000) ;; variation
+             (advance-file-position stream (- length 6)))
+            ;; otherwise error
+            (otherwise
+             (error 'unsupported-format
+                    :description "kerning subtable coverage"
+                    :size 2
+                    :expected-values (list 0 #x2000 #x4000 #x8000)
+                    :actual-value coverage-flags))))))))
 
 (defmethod all-kerning-pairs ((font-loader font-loader))
   (let ((pairs nil))

--- a/name.lisp
+++ b/name.lisp
@@ -77,9 +77,9 @@
     :big5
     :wansung
     :johab
-    :reserved
-    :reserved
-    :reserved
+    :7-reserved
+    :8-reserved
+    :9-reserved
     :ucs-4))
 
 (defvar *macintosh-encoding-ids*
@@ -117,18 +117,29 @@
     :sindhi
     :uninterpreted))
 
+(defvar *iso-encoding-ids*
+  #(:7-bit-ascii
+    :iso-10646
+    :iso-8859-1))
+
 (defparameter *encoding-tables*
   (vector *unicode-encoding-ids*
           *macintosh-encoding-ids*
-          nil
+          *iso-encoding-ids*
           *microsoft-encoding-ids*
           nil))
 
 (defun encoding-id-name (platform-id encoding-id)
-  (aref (aref *encoding-tables* platform-id) encoding-id))
+  (if (and (array-in-bounds-p *encoding-tables* platform-id)
+           (aref *encoding-tables* platform-id)
+           (array-in-bounds-p (aref *encoding-tables* platform-id) encoding-id))
+      (aref (aref *encoding-tables* platform-id) encoding-id)
+      encoding-id))
 
 (defun platform-id-name (platform-id)
-  (aref *platform-identifiers* platform-id))
+  (if (array-in-bounds-p *platform-identifiers* platform-id)
+      (aref *platform-identifiers* platform-id)
+      platform-id))
 
 (defparameter *macroman-translation-table*
   #(#x00 #x00

--- a/post.lisp
+++ b/post.lisp
@@ -245,8 +245,7 @@
       (warn "Glyph count in \"post\" table (~D) ~
              does not match glyph count in \"maxp\" table (~D). ~
              This font may be broken."
-            glyph-count name-count)
-      (setf glyph-count name-count))
+            glyph-count name-count))
     ;; This is done in a couple passes. First, initialize the names
     ;; tables with indexes into either the standard table or the
     ;; pstring table.


### PR DESCRIPTION
INVERT-CHARACTER-MAP was very slow on large fonts, taking up to a few seconds to open a single font. With optimizations it can open ~2000 fonts in ~6 seconds on same machine.

Don't get stuck in a loop when compound contours contain themselves.

Handle more kerning table formats, and try more cmap tables (symbol fonts will probably load as #xf000 range 'private use area' code points, but better than nothing).

Also tries to improve a few error messages.
