### PR TITLE
Add vertical metric loaders to ZPB-TTF

### DIFF
--- a/font-loader-interface.lisp
+++ b/font-loader-interface.lisp
@@ -133,6 +133,8 @@
       (load-post-info font-loader)
       (load-hhea-info font-loader)
       (load-hmtx-info font-loader)
+      (load-vhea-info font-loader)
+      (load-vmtx-info font-loader)
       (setf (glyph-cache font-loader)
             (make-array (glyph-count font-loader) :initial-element nil))
       font-loader)))

--- a/font-loader.lisp
+++ b/font-loader.lisp
@@ -55,6 +55,14 @@
    ;; from the 'hmtx' table
    (advance-widths :accessor advance-widths)
    (left-side-bearings :accessor left-side-bearings)
+   ;; from the 'vhea' table
+   (vhea-missing-p :initform nil :accessor vhea-missing-p)
+   (vascender :accessor vascender)
+   (vdescender :accessor vascender)
+   ;; from 'vhea' and 'vmtx' tables
+   (vmtx-missing-p :initform nil :accessor vmtx-missing-p)
+   (advance-heights :accessor advance-heights)
+   (top-side-bearings :accessor top-side-bearings)
    ;; from the 'kern' table
    (kerning-table :initform (make-hash-table) :accessor kerning-table)
    ;; from the 'name' table

--- a/font-loader.lisp
+++ b/font-loader.lisp
@@ -51,6 +51,7 @@
    (ascender :accessor ascender)
    (descender :accessor descender)
    (line-gap :accessor line-gap)
+   (max-width :accessor max-width)
    ;; from the 'hmtx' table
    (advance-widths :accessor advance-widths)
    (left-side-bearings :accessor left-side-bearings)

--- a/glyf.lisp
+++ b/glyf.lisp
@@ -232,6 +232,8 @@ update the X and Y values of each point."
             (setf (aref merged i) contour)
             (incf i)))))
 
+(defvar *compound-contour-loop-check*)
+
 (defun read-compound-contours (loader)
   (let ((contours-list '())
         (stream (input-stream loader)))
@@ -345,7 +347,6 @@ box, read the contours data from STREAM and return it as a vector."
                          (subseq control-points start (1+ end))))
           contours)))))
 
-(defvar *compound-contour-loop-check*)
 (defmacro with-compound-contour-loop (() &body body)
   `(let ((*compound-contour-loop-check*
            (if (boundp '*compound-contour-loop-check*)

--- a/glyph.lisp
+++ b/glyph.lisp
@@ -82,6 +82,8 @@ to look up information in various structures in the truetype file.")
 
 ;;; Glyph-specific values determined from data in the font-loader
 
+;;; Horizontal metrics
+
 (defgeneric left-side-bearing (object)
   (:method ((glyph glyph))
     (bounded-aref (left-side-bearings (font-loader glyph))
@@ -89,6 +91,41 @@ to look up information in various structures in the truetype file.")
 
 (defmethod (setf left-side-bearing) (new-value glyph)
   (setf (bounded-aref (left-side-bearings (font-loader glyph))
+                      (font-index glyph))
+        new-value))
+
+(defgeneric advance-width (object)
+  (:method ((glyph glyph))
+    (bounded-aref (advance-widths (font-loader glyph))
+                  (font-index glyph))))
+
+(defmethod (setf advance-width) (new-value (glyph glyph))
+  (setf (bounded-aref (advance-widths (font-loader glyph))
+                      (font-index glyph))
+        new-value))
+
+;;; Vertical metrics
+
+(defgeneric top-side-bearing (object)
+  (:method ((glyph glyph))
+    (let ((loader (font-loader glyph)))
+      (if (vmtx-missing-p loader)
+          (- (ascender loader) (ymax glyph))
+          (bounded-aref (top-side-bearings (font-loader glyph))
+                        (font-index glyph))))))
+
+(defmethod (setf top-side-bearing) (new-value glyph)
+  (setf (bounded-aref (top-side-bearings (font-loader glyph))
+                      (font-index glyph))
+        new-value))
+
+(defgeneric advance-height (object)
+  (:method ((glyph glyph))
+    (bounded-aref (advance-heights (font-loader glyph))
+                  (font-index glyph))))
+
+(defmethod (setf advance-height) (new-value (glyph glyph))
+  (setf (bounded-aref (advance-heights (font-loader glyph))
                       (font-index glyph))
         new-value))
 
@@ -115,16 +152,6 @@ to look up information in various structures in the truetype file.")
 (defmethod kerning-offset (left (right null) font-loader)
   (declare (ignore left right font-loader))
   0)
-
-(defgeneric advance-width (object)
-  (:method ((glyph glyph))
-    (bounded-aref (advance-widths (font-loader glyph))
-                  (font-index glyph))))
-
-(defmethod (setf advance-width) (new-value (glyph glyph))
-  (setf (bounded-aref (advance-widths (font-loader glyph))
-                      (font-index glyph))
-        new-value))
 
 (defgeneric kerned-advance-width (object next)
   (:method ((object glyph) next)

--- a/hhea.lisp
+++ b/hhea.lisp
@@ -26,8 +26,8 @@
 ;;;
 ;;; Loading data from the "hhea" table.
 ;;;
-;;;  https://docs.microsoft.com/en-us/typography/opentype/spec/hhea
-;;;  http://developer.apple.com/fonts/TTRefMan/RM06/Chap6hhea.html
+;;;  https://learn.microsoft.com/en-us/typography/opentype/spec/hhea
+;;;  https://developer.apple.com/fonts/TrueType-Reference-Manual/RM06/Chap6hhea.html
 ;;;
 ;;; $Id: hhea.lisp,v 1.4 2006/02/18 23:13:43 xach Exp $
 

--- a/hhea.lisp
+++ b/hhea.lisp
@@ -35,13 +35,14 @@
 
 (defmethod load-hhea-info ((font-loader font-loader))
   (seek-to-table "hhea" font-loader)
-  (with-slots (input-stream ascender descender line-gap)
+  (with-slots (input-stream ascender descender line-gap max-width)
       font-loader
     (let ((version (read-fixed input-stream)))
       (check-version "\"hhea\" table" version #x00010000))
     (setf ascender (read-fword input-stream)
           descender (read-fword input-stream)
-          line-gap (read-fword input-stream))))
+          line-gap (read-fword input-stream)
+          max-width (read-ufword input-stream))))
 
 (defmethod horizontal-metrics-count ((font-loader font-loader))
   (seek-to-table "hhea" font-loader)

--- a/hmtx.lisp
+++ b/hmtx.lisp
@@ -26,8 +26,8 @@
 ;;;
 ;;; Loading data from the "hmtx" table.
 ;;;
-;;;  https://docs.microsoft.com/en-us/typography/opentype/spec/hmtx
-;;;  http://developer.apple.com/fonts/TTRefMan/RM06/Chap6hmtx.html
+;;;  https://learn.microsoft.com/en-us/typography/opentype/spec/hmtx
+;;;  https://developer.apple.com/fonts/TrueType-Reference-Manual/RM06/Chap6hmtx.html
 ;;;
 ;;; $Id: hmtx.lisp,v 1.3 2006/02/18 23:13:43 xach Exp $
 

--- a/package.lisp
+++ b/package.lisp
@@ -49,6 +49,8 @@
    #:descender
    #:line-gap
    #:max-width
+   #:vascender
+   #:vdescender
    ;; other font attributes
    #:postscript-name
    #:full-name
@@ -81,7 +83,9 @@
    #:font-index
    ;; glyph typographic
    #:advance-width
+   #:advance-height
    #:left-side-bearing
+   #:top-side-bearing
    #:right-side-bearing
    #:kerning-offset
    #:string-bounding-box))

--- a/package.lisp
+++ b/package.lisp
@@ -48,6 +48,7 @@
    #:ascender
    #:descender
    #:line-gap
+   #:max-width
    ;; other font attributes
    #:postscript-name
    #:full-name

--- a/util.lisp
+++ b/util.lisp
@@ -67,6 +67,9 @@
 (defun read-fword (stream)
   (read-int16 stream))
 
+(defun read-ufword (stream)
+  (read-uint16 stream))
+
 (defun read-fixed2.14 (stream)
   (let ((value (read-uint16 stream)))
     (let ((integer (ash value -14))

--- a/vhea.lisp
+++ b/vhea.lisp
@@ -1,0 +1,66 @@
+;;; Copyright (c) 2024 Daniel Kochmański, All Rights Reserved
+;;;
+;;; Redistribution and use in source and binary forms, with or without
+;;; modification, are permitted provided that the following conditions
+;;; are met:
+;;;
+;;;   * Redistributions of source code must retain the above copyright
+;;;     notice, this list of conditions and the following disclaimer.
+;;;
+;;;   * Redistributions in binary form must reproduce the above
+;;;     copyright notice, this list of conditions and the following
+;;;     disclaimer in the documentation and/or other materials
+;;;     provided with the distribution.
+;;;
+;;; THIS SOFTWARE IS PROVIDED BY THE AUTHOR 'AS IS' AND ANY EXPRESSED
+;;; OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+;;; WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+;;; ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY
+;;; DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+;;; DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE
+;;; GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+;;; INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+;;; WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+;;; NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+;;; SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+;;;
+;;; Loading data from the "vhea" table.
+;;;
+;;;  https://learn.microsoft.com/en-us/typography/opentype/spec/vhea
+;;;  https://developer.apple.com/fonts/TrueType-Reference-Manual/RM06/Chap6vhea.html
+;;;
+
+(in-package #:zpb-ttf)
+
+;;; Tables 'vhea' and 'vmtx' are not present in some fonts. For that reason we
+;;; have a fallback where metrics are supplanted with default values based on
+;;; horizontal metrics.
+
+(defmethod load-vhea-info ((font-loader font-loader))
+  (unless (table-info "vhea" font-loader)
+    (setf (vhea-missing-p font-loader) t)
+    (let ((dx (/ (max-width font-loader) 2)))
+      (with-slots (vascender vdescender)
+          font-loader
+        (setf vascender dx
+              vdescender (- dx))))
+    (return-from load-vhea-info))
+  (seek-to-table "vhea" font-loader)
+  (with-slots (input-stream vascender vdescender)
+      font-loader
+    (let ((version (read-fixed input-stream)))
+      (check-version "\"vhea\" table" version #x00010000 #x00011000))
+    (setf vascender (read-fword input-stream)
+          vdescender (read-fword input-stream))))
+
+(defmethod vertical-metrics-count ((font-loader font-loader))
+  (when (or (vhea-missing-p font-loader)
+            (null (table-info "vhea" font-loader)))
+    ;; (warn "Table 'vhea' is missing.")
+    (setf (vhea-missing-p font-loader) t)
+    (return-from vertical-metrics-count))
+  (seek-to-table "vhea" font-loader)
+  (with-slots (input-stream) font-loader
+    ;; Skip to the end, since all we care about is the last item
+    (advance-file-position input-stream 34)
+    (read-uint16 input-stream)))

--- a/vmtx.lisp
+++ b/vmtx.lisp
@@ -1,0 +1,58 @@
+;;; Copyright (c) 2024 Daniel Kochmański, All Rights Reserved
+;;;
+;;; Redistribution and use in source and binary forms, with or without
+;;; modification, are permitted provided that the following conditions
+;;; are met:
+;;;
+;;;   * Redistributions of source code must retain the above copyright
+;;;     notice, this list of conditions and the following disclaimer.
+;;;
+;;;   * Redistributions in binary form must reproduce the above
+;;;     copyright notice, this list of conditions and the following
+;;;     disclaimer in the documentation and/or other materials
+;;;     provided with the distribution.
+;;;
+;;; THIS SOFTWARE IS PROVIDED BY THE AUTHOR 'AS IS' AND ANY EXPRESSED
+;;; OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+;;; WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+;;; ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY
+;;; DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+;;; DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE
+;;; GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+;;; INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+;;; WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+;;; NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+;;; SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+;;;
+;;;
+;;; Loading data from the 'vmtx' table.
+;;;
+;;;  https://learn.microsoft.com/en-us/typography/opentype/spec/vmtx
+;;;  https://developer.apple.com/fonts/TrueType-Reference-Manual/RM06/Chap6vmtx.html
+;;;
+
+(in-package #:zpb-ttf)
+
+;;; Tables 'vhea' and 'vmtx' are not present in some fonts. For that reason we
+;;; have a fallback where metrics are supplanted with default values based on
+;;; horizontal metrics.
+
+(defmethod load-vmtx-info ((font-loader font-loader))
+  (when (or (vhea-missing-p font-loader)
+            (null (table-info "vmtx" font-loader)))
+    (setf (vmtx-missing-p font-loader) t)
+    (let ((line-height (- (ascender font-loader) (descender font-loader))))
+      ;; TOP-SIDE-BEARING depends on individual glyph metric YMAX.
+      (setf (advance-heights font-loader)
+            (make-array 1 :initial-element line-height)))
+    (return-from load-vmtx-info))
+  (let* ((vertical-metrics-count (vertical-metrics-count font-loader))
+         (advance-heights (make-array vertical-metrics-count))
+         (top-side-bearings (make-array vertical-metrics-count)))
+    (seek-to-table "vmtx" font-loader)
+    (with-slots (input-stream) font-loader
+      (dotimes (i vertical-metrics-count)
+        (setf (svref advance-heights i) (read-uint16 input-stream))
+        (setf (svref top-side-bearings i) (read-int16 input-stream))))
+    (setf (advance-heights font-loader) advance-heights
+          (top-side-bearings font-loader) top-side-bearings)))

--- a/zpb-ttf.asd
+++ b/zpb-ttf.asd
@@ -63,6 +63,16 @@
                                    "util"
                                    "font-loader"
                                    "hhea"))
+               (:file "vhea"
+                      :depends-on ("package"
+                                   "util"
+                                   "font-loader"
+                                   "hhea"))
+               (:file "vmtx"
+                      :depends-on ("package"
+                                   "util"
+                                   "font-loader"
+                                   "vhea"))
                (:file "glyf"
                       :depends-on ("package"
                                    "util"
@@ -89,6 +99,8 @@
                                    "cmap"
                                    "post"
                                    "hhea"
-                                   "hmtx"))))
+                                   "hmtx"
+                                   "vhea"
+                                   "vmtx"))))
 
 


### PR DESCRIPTION
Some (not all) fonts contain vertical metric tables. This is necessary to handle correctly top-to-bottom fonts. This pull request adds appropriate loaders and a fallback mechanism that bases missing vertical metrics on horizontal ones:

- advance-height -- line-height
- vertical ascender/descender -- half of the maximal advance-width
